### PR TITLE
improve CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -42,4 +42,4 @@ jobs:
         - name: "install awesome-bot"
           run: gem install awesome_bot
         - name: "linting: ${{ matrix.files }}"
-          run: awesome_bot --allow-redirect ${{ matrix.files }}
+          run: awesome_bot --allow-redirect ${{ matrix.files }} --white-list crates.io


### PR DESCRIPTION
crates.io is misreported as an error, `--white-list crates.io` flag fixes that

also fixes check at #67 