### PR TITLE
Move revoltmini to discontinued projects section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -107,7 +107,6 @@ For a full list of clients with more information, check out the [Revolt Clients 
 - [Mobile App: Clerotri](https://github.com/upryzing/clerotri) - Revolt client for Android and web, built with React Native.
 - [Mobile App: Unoffical Revolt Android App](https://github.com/ashpotter/revolt-mobile) - Revolt Android app based on ASW.
 - [Svolte](https://github.com/itzTheMeow/revolt-svolte) - Revolt client made in Svelte with better mobile/PWA support and QOL features.
-- [RevoltMini](https://codeberg.org/amycatgirl/revoltmini) - Revolt client for relatively small, low-end smartphones.
 
 ## ❌ Discontinued Projects
 
@@ -117,6 +116,7 @@ For a full list of clients with more information, check out the [Revolt Clients 
 - [PhotoBox](https://github.com/PhotoBoxPW/PhotoBoxRevolt) - A bot that creates and morphs images into fun memes or with crazy filters.
 - [defectio](https://github.com/LimeProgramming/defectio) - Asyncronous and typed Python library for Revolt.
 - [Revolt.Cli: TUI client for Revolt](https://github.com/Jan0660/Revolt.Cli) - Terminal.Gui based CLI client writen in C#.
+- [RevoltMini](https://codeberg.org/amycatgirl/revoltmini) - Revolt client for relatively small, low-end smartphones.
 - [Taco](https://github.com/Jan0660/Taco) - Multi-purpose bot, includes Discord bridge.
 - [Voltare](https://github.com/Dexare/Voltare) - Typed, modular and extendable Revolt bot framework.
 


### PR DESCRIPTION
RevoltMini (or stoatmini, i guess) has been deprecated and archived since August 17, 2025 since I haven't really updated it since last year and burned myself out trying to rewrite it, and I feel like the current web clients are small enough to run on low end devices as of late.

So this PR moves it from the third-party clients section to the discontinued projects section.