### PR TITLE
Replace seria with kaho in Rust section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ An awesome list of things for Stoat, the chat app that's truly built with you in
 ### Rust
 
 - [Rive](https://crates.io/crates/rive) - A Rust ecosystem for Stoat.
-- [Seria](https://github.com/reinacchi/seria) - A Rust-based library for interacting with Stoat.
+- [Kaho](https://github.com/reinacchi/kaho) - A Rust-based library for interacting with Stoat.
 - [Stoat-rs](https://github.com/Zomatree/rust-stoat-sdk) - A Rust-based wrapper for the Stoat API.
 
 ### Swift


### PR DESCRIPTION
I'd like to update my Stoat's Rust library to a new package as Stoat has been rebranded.